### PR TITLE
[feat] Added sponsors section and sponsors page

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -7,7 +7,14 @@ const Navbar = () => {
   return (
     <Wrapper>
       <Container>
-        <img src={Logo} width="169" alt="HackSC 2020 logo" />
+        <a href="/">
+          <img src={Logo} width="169" alt="HackSC 2020 logo" />
+        </a>
+
+        <Links>
+          <a href="/">Overview</a>
+          <a href="/sponsor">Sponsorship</a>
+        </Links>
       </Container>
     </Wrapper>
   );
@@ -22,6 +29,23 @@ const Container = styled.div`
   max-width: 960px;
   margin-left: auto;
   margin-right: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Links = styled.div`
+  a {
+    padding: 0 12px;
+    color: #1c1c1c;
+    font-weight: 700;
+    font-size: 14px;
+    text-transform: uppercase;
+  }
+
+  ${({ theme }) => theme.media.mobile`
+    display: none;
+  `}
 `;
 
 export default Navbar;

--- a/components/Sponsors.js
+++ b/components/Sponsors.js
@@ -1,0 +1,75 @@
+import styled from "styled-components";
+
+import { Header, Body } from "./type";
+import Button from "./Button";
+
+const Sponsors = () => {
+  return (
+    <Wrapper>
+      <Row>
+        <Column>
+          <SponsorsHeader>Sponsors</SponsorsHeader>
+
+          <Body>
+            Each year, our sponsors help us unite 800+ emerging developers,
+            designers, and builders. Our sponsors make it possible for hackers
+            to build something they're proud of.
+          </Body>
+          <Body>
+            Interested in sponsoring? E-mail us at{" "}
+            <a href="mailto:sponsorship@hacksc.com" target="_blank">
+              sponsorship@hacksc.com
+            </a>
+          </Body>
+
+          <div>
+            <LearnMoreButton as="a" href="/sponsor">
+              Learn More
+            </LearnMoreButton>
+          </div>
+        </Column>
+      </Row>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  width: 93.75%;
+  max-width: 960px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 75px;
+  padding-bottom: 75px;
+  flex-direction: column;
+`;
+
+const SponsorsHeader = styled(Header)`
+  margin-bottom: 12px;
+`;
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  ${({ theme }) => theme.media.tablet`
+    flex-direction: column;
+  `}
+`;
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  ${({ theme }) => theme.media.tablet`
+    flex-basis: 100%;
+  `}
+`;
+
+const LearnMoreButton = styled(Button)`
+  font-weight: 600;
+  display: inline-block;
+  padding: 16px 40px;
+`;
+
+export default Sponsors;

--- a/components/index.js
+++ b/components/index.js
@@ -2,6 +2,7 @@ export { default as Navbar } from "./Navbar";
 export { default as Hero } from "./Hero";
 export { default as MetaTags } from "./MetaTags";
 export { default as Details } from "./Details";
+export { default as Sponsors } from "./Sponsors";
 export { default as Verticals } from "./Verticals";
 export { default as Footer } from "./Footer";
 export { default as MLH } from "./MLH";

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import {
   Hero,
   MetaTags,
   Details,
+  Sponsors,
   Verticals,
   Footer,
   MLH
@@ -17,6 +18,7 @@ const Landing = () => {
       <Hero />
       <Details />
       <Verticals />
+      <Sponsors />
       <Footer />
       <MLH />
     </>

--- a/pages/sponsor.js
+++ b/pages/sponsor.js
@@ -14,7 +14,7 @@ const Sponsor = () => {
       <Wrapper>
         <Header>Sponsor Us</Header>
         <StyledBody>
-          This January, HackSC will bring <Bold>1000+</Bold> hackers to the
+          This January, HackSC will bring <Bold>800+</Bold> hackers to the
           University of Southern California. Students will have 36 hours to
           create lasting, innovative and impactful products. Sponsors will have
           an outstanding opportunity to{" "}
@@ -34,7 +34,7 @@ const Sponsor = () => {
 
           <Stats>
             <Stat>
-              <Number>600+</Number> attendees
+              <Number>800+</Number> attendees
             </Stat>
             <Stat>
               <Number>100</Number> projects submitted

--- a/pages/sponsor.js
+++ b/pages/sponsor.js
@@ -1,0 +1,148 @@
+import styled from "styled-components";
+
+import { Navbar, MetaTags, Footer, MLH } from "../components";
+
+import { Header, Body, Bold } from "../components/type";
+
+const Sponsor = () => {
+  return (
+    <>
+      <MetaTags title="HackSC 2020 - Sponsorship" />
+
+      <Navbar />
+
+      <Wrapper>
+        <Header>Sponsor Us</Header>
+        <StyledBody>
+          This January, HackSC will bring <Bold>1000+</Bold> hackers to the
+          University of Southern California. Students will have 36 hours to
+          create lasting, innovative and impactful products. Sponsors will have
+          an outstanding opportunity to{" "}
+          <Bold>promote your own products and APIs,</Bold> as well as{" "}
+          <Bold>access top talent</Bold> from around the country.
+        </StyledBody>
+
+        <StyledBody>
+          Interested in sponsoring? E-mail us at{" "}
+          <a href="mailto:sponsorship@hacksc.com" target="_blank">
+            sponsorship@hacksc.com
+          </a>
+        </StyledBody>
+
+        <StatsSection>
+          <Subheader>Last Year's Successes</Subheader>
+
+          <Stats>
+            <Stat>
+              <Number>600+</Number> attendees
+            </Stat>
+            <Stat>
+              <Number>100</Number> projects submitted
+            </Stat>
+            <Stat>
+              <Number>40:60</Number> female:male ratio
+            </Stat>
+            <Stat>
+              <Number>145</Number> # of schools applied
+            </Stat>
+
+            <Stat>
+              <Number>400+</Number> usc students
+            </Stat>
+            <Stat>
+              <Number>2500+</Number> # of applicants
+            </Stat>
+            <Stat>
+              <Number>92</Number> # of prizes awarded
+            </Stat>
+            <Stat>
+              <Number>15</Number> puppies
+            </Stat>
+
+            <Stat>
+              <Number>3000</Number> lbs of soylent
+            </Stat>
+            <Stat>
+              <Number>40</Number> judges
+            </Stat>
+            <Stat>
+              <Number>30</Number> sponsors
+            </Stat>
+            <Stat>
+              <Number>infinite</Number> memories made
+            </Stat>
+          </Stats>
+        </StatsSection>
+      </Wrapper>
+
+      <Footer />
+      <MLH />
+    </>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  width: 93.75%;
+  max-width: 960px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 75px;
+  padding-bottom: 75px;
+  flex-direction: column;
+`;
+
+const StyledBody = styled(Body)`
+  font-size: 22px;
+  line-height: 32px;
+  margin-top: 16px;
+`;
+
+const StatsSection = styled.div`
+  padding: 64px 0;
+`;
+
+const Subheader = styled.h2`
+  font-size: 32px;
+  font-weight: 700;
+  text-transform: uppercase;
+  margin-bottom: 32px;
+`;
+
+const Stats = styled.div`
+  display: flex;
+  color: #ff5353;
+  justify-content: space-between;
+  flex-wrap: wrap;
+`;
+
+const Stat = styled.div`
+  flex-basis: 23%;
+  background: peach;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  height: 120px;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 83, 83, 0.1);
+  border-radius: 8px;
+  font-weight: 600;
+  margin-bottom: 20px;
+
+  ${({ theme }) => theme.media.desktop`
+    flex-basis: 48%;
+  `}
+
+  ${({ theme }) => theme.media.mobile`
+    flex-basis: 100%;
+  `}
+`;
+
+const Number = styled.span`
+  font-weight: 700;
+  font-size: 32px;
+  margin-bottom: 8px;
+`;
+
+export default Sponsor;


### PR DESCRIPTION
Added initial sponsors section to home page

<img width="1178" alt="Screen Shot 2019-10-27 at 7 39 21 PM" src="https://user-images.githubusercontent.com/4969041/67648009-99a45000-f8f1-11e9-9202-1ca8dfbbf5dc.png">

Added sponsors page to direct potential sponsors to 

<img width="1137" alt="Screen Shot 2019-10-27 at 7 39 25 PM" src="https://user-images.githubusercontent.com/4969041/67648014-9e690400-f8f1-11e9-8465-e3883cc5fbe8.png">

